### PR TITLE
Hiding executors on user side using ScopedValues.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "1.0.0"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
+ScopedValues = "7e506255-f358-4e82-b7e4-beb19740aa63"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 ginkgo_jll = "e4326e8b-370f-5d90-bbd6-f077a22d5a69"
 

--- a/examples/simple-solver/simple-solver.jl
+++ b/examples/simple-solver/simple-solver.jl
@@ -7,26 +7,28 @@ const (Tv, Ti) = (Float32, Int32)
 version()
 
 # Obtain executor with a specific backend
-exec = create(:omp)
+const exec = create(:omp)
 
-# Read matrix and vector from mtk files
-A = GkoCsr{Tv, Ti}("data/A.mtx", exec)
-b = GkoDense{Tv}("data/b.mtx", exec)
-x = GkoDense{Tv}("data/x0.mtx", exec)
+# Specify executor to be passed for matrix creation including CSR, Dense and "number" and cg solver
+@with EXECUTOR => exec begin
+  # Read matrix and vector from mtk files, now omit the passing of exec
+  A = GkoCsr{Tv, Ti}("data/A.mtx");
+  b = GkoDense{Tv}("data/b.mtx");
+  x = GkoDense{Tv}("data/x0.mtx");
+  
+  cg!(x, A, b; maxiter = 20, reduction = 1.0e-7)
 
-cg!(exec, x, A, b; maxiter = 20, reduction = 1.0e-7)
+  @info "Solution (x):"
+  display(x)
+  
+  one     = number(Tv(1.0))
+  neg_one = number(Tv(-1.0))
+  res     = number(Tv(0.0))
 
-@info "Solution (x):"
-display(x)
-
-one     = number(exec, Tv(1.0))
-neg_one = number(exec, Tv(-1.0))
-res     = number(exec, Tv(0.0))
-
-# x = one*A*b + neg_one*x
-spmm!(A, one, x, neg_one, b)
-
-
-norm2!(b, res)
-@info "Residual norm sqrt(r^T r):"
-display(res)
+  # x = one*A*b + neg_one*x
+  spmm!(A, one, x, neg_one, b)
+  
+  norm2!(b, res)
+  @info "Residual norm sqrt(r^T r):"
+  display(res)
+end

--- a/src/Ginkgo.jl
+++ b/src/Ginkgo.jl
@@ -1,5 +1,9 @@
 module Ginkgo
 
+# Hide executors
+using ScopedValues
+export with, @with
+
 using SparseArrays
 
 # Import helper functions for documentation purposes
@@ -26,6 +30,7 @@ include("matrix/Csr.jl")
 
 include("solver/CG.jl")
 
+const EXECUTOR = ScopedValue(GkoExecutor(:omp)); export EXECUTOR
 
 # Export supported types for Ginkgo.jl
 export

--- a/src/solver/CG.jl
+++ b/src/solver/CG.jl
@@ -1,5 +1,5 @@
 # gko::solver::Cg<T>
-function cg!(exec::GkoExecutor, x::Ginkgo.GkoDense{Tv}, A::Ginkgo.GkoCsr{Tv, Ti}, b::Ginkgo.GkoDense{Tv};
+function cg!(x::Ginkgo.GkoDense{Tv}, A::Ginkgo.GkoCsr{Tv, Ti}, b::Ginkgo.GkoDense{Tv};
     abstol::Real = zero(real(eltype(b))),
     reltol::Real = sqrt(eps(real(eltype(b)))),
     reduction::Real = 1e-3,
@@ -11,5 +11,5 @@ function cg!(exec::GkoExecutor, x::Ginkgo.GkoDense{Tv}, A::Ginkgo.GkoCsr{Tv, Ti}
     kwargs...) where {Tv, Ti}
 
     # Store the result in the x
-    API.ginkgo_solver_cg_solve(exec.ptr, A.ptr, b.ptr, x.ptr, maxiter, reduction)
+    API.ginkgo_solver_cg_solve(EXECUTOR[].ptr, A.ptr, b.ptr, x.ptr, maxiter, reduction)
 end

--- a/test/matrix/test-csr.jl
+++ b/test/matrix/test-csr.jl
@@ -1,24 +1,22 @@
 # gko::matrix::Csr<T>
-
 for (Tv, Ti) in Iterators.product(SUPPORTED_CSR_ELTYPE, SUPPORTED_CSR_INDEXTYPE)
     @testset "Integration test: gko::matrix::Csr<$Tv, $Ti> read from file and retrieve information            " begin
 
         exec = create(:omp)
-        A = Ginkgo.GkoCsr{Tv, Ti}("matrix/data/A.mtx", exec)
-    
-        # Retrive dimensions
-        @test Ginkgo.size(A)  == (19, 19)
-    
-        # Retrive nnz in the sparse matrix, number of elements stored
-        @test Ginkgo.nnz(A)   == 147
-    
-        # Detail
-        @test Ginkgo.srows(A) == 0
+        with(EXECUTOR => exec) do
+            A = Ginkgo.GkoCsr{Tv, Ti}("matrix/data/A.mtx")
+
+            # Retrive dimensions
+            @test Ginkgo.size(A)  == (19, 19)
         
-        # Retrive arrays
-        # @test Ginkgo.rowptr(A) ==
-        # @test Ginkgo.colvals(A) ==
-        # @test Ginkgo.nonzeros(A) ==
+            # Retrive nnz in the sparse matrix, number of elements stored
+            @test Ginkgo.nnz(A)   == 147
+        
+            # Detail
+            @test Ginkgo.srows(A) == 0
+        end
+
+
     end
 
 

--- a/test/matrix/test-dense.jl
+++ b/test/matrix/test-dense.jl
@@ -4,37 +4,43 @@
 exec = create(:omp)
 
 for T in SUPPORTED_DENSE_ELTYPE
-    # Create unitialized matrix, will trigger warnings
-    M    = Ginkgo.GkoDense{T}(exec, Ginkgo.GkoDim{2}(2, 3))
-    N    = Ginkgo.GkoDense{T}(exec, 8)
 
-    # Create initialized vector
-    vec1 = Ginkgo.GkoDense{T}(exec, 3, 1)
-    fill!(vec1, T(1.0))
 
-    @testset "Unit test: gko::matrix::Dense<$T> size                " begin
-        @test Ginkgo.size(M) == (2, 3)
-        @test Ginkgo.size(N) == (8, 8)
+    with(EXECUTOR => exec) do
+        # Create unitialized matrix, will trigger warnings
+        M    = Ginkgo.GkoDense{T}(Ginkgo.GkoDim{2}(2, 3))
+        N    = Ginkgo.GkoDense{T}(8)
+
+        # Create initialized vector
+        vec1 = Ginkgo.GkoDense{T}(3, 1)
+        fill!(vec1, T(1.0))
+
+        @testset "Unit test: gko::matrix::Dense<$T> size                " begin
+            @test Ginkgo.size(M) == (2, 3)
+            @test Ginkgo.size(N) == (8, 8)
+        end
+
+        @testset "Unit test: gko::matrix::Dense<$T> no. element entries " begin
+            @test Ginkgo.elements(M) == 6
+            @test Ginkgo.elements(N) == 64
+        end
+
+        @testset "Unit test: gko::matrix::Dense<$T> get index          " begin
+            num  = Ginkgo.number(T(88.9))
+            @test num[1,1] ≈ 88.9
+        end
+
+        @testset "Unit test: gko::matrix::Dense<$T> compute norms      " begin
+            res = Ginkgo.number(T(0.0))
+            Ginkgo.norm1!(vec1, res)
+            @test res[1,1] == 3
+
+            Ginkgo.norm2!(vec1, res)
+
+            # ≈ for the numerical instability
+            @test res[1,1] ≈ sqrt(3)
+        end
+
     end
 
-    @testset "Unit test: gko::matrix::Dense<$T> no. element entries " begin
-        @test Ginkgo.elements(M) == 6
-        @test Ginkgo.elements(N) == 64
-    end
-
-    @testset "Unit test: gko::matrix::Dense<$T> get index          " begin
-        num  = Ginkgo.number(exec, T(88.9))
-        @test num[1,1] ≈ 88.9
-    end
-
-    @testset "Unit test: gko::matrix::Dense<$T> compute norms      " begin
-        res = Ginkgo.number(exec, T(0.0))
-        Ginkgo.norm1!(vec1, res)
-        @test res[1,1] == 3
-
-        Ginkgo.norm2!(vec1, res)
-
-        # ≈ for the numerical instability
-        @test res[1,1] ≈ sqrt(3)
-    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using Ginkgo
+using ScopedValues
 using Test
 
 include("test-configurations.jl")


### PR DESCRIPTION
In issue #12 we addressed the wish to hide the executors when creating matrices/solvers etc. where in C++ ginkgo library, passing the executor during matrix/solver intialization is needed. Here with [`ScopedValues.jl`](https://github.com/vchuravy/ScopedValues.jl) we can avoid this "passing" by defining the executor to be a dynamically scoped value.

It is working fine so far but it requires a different syntax that we need to force our users to adapt to. Where users need to write code within either `@with` macro or `with` scope, for a concrete example see [here](https://github.com/youwuyou/Ginkgo.jl/blob/3e3939168092eb9c3ece238bc6f9b6bab496d6c3/examples/simple-solver/simple-solver.jl#L13).

```julia
@with EXECUTOR => exec
    ...
end
```

Or using `with`

```julia
with(EXECUTOR => exec) do
  ...
end
```

For developers we need not much changes though, see an example of Csr matrix [here](https://github.com/youwuyou/Ginkgo.jl/blob/3e3939168092eb9c3ece238bc6f9b6bab496d6c3/src/matrix/Csr.jl#L21-L32)

Would this be something desirable for long-term for our package?
